### PR TITLE
#20: Add defensive programming for entity object

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Thumbnail integration](#thumbnail-integration)
   - [Handling thumbnail errors](#handling-thumbnail-errors)
 - [Caching of mpx responses](#caching-of-mpx-responses)
+- [Media access and availability calculations](#media-access-and-availability-calculations)
 - [Limiting results during an mpx import](#limiting-results-during-an-mpx-import)
   - [1. Altering import mpx queries](#1-altering-import-mpx-queries)
   - [2. Altering ingested mpx objects](#2-altering-ingested-mpx-objects)
@@ -111,6 +112,16 @@ $factory->load('http://data.media.theplatform.com/media/data/Media/2602559', ['h
 
 Note that this will incur a significant performance hit on the order of 500ms
 or more, so use this option sparingly and rely on cached data where possible.
+
+## Media access and availability calculations
+
+Access to an mpx media entity is calculated using the mpx available and
+expiration dates. By default, after a site cache clear those videos will
+need to be re-fetched from mpx to have up-to-date availability dates. To
+improve performance, map the available and expiration dates to Date / Time
+fields. If available, those fields will be used to calculate access
+permissions. For details, see the
+[MediaAvailableAccess](src/Access/MediaAvailableAccess.php) class.
 
 ## Limiting results during an mpx import
 

--- a/migrations/d7_media_theplatform_mpx.yml
+++ b/migrations/d7_media_theplatform_mpx.yml
@@ -3,6 +3,7 @@ label: File entity to Media MPX migration
 audit: true
 migration_tags:
   - Drupal 7
+  - Content
 deriver: Drupal\media_mpx\Plugin\migrate\MpxItemDeriver
 source:
   plugin: media_mpx_entity_item

--- a/src/PlayerMetadata.php
+++ b/src/PlayerMetadata.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\media\Entity\Media as DrupalMedia;
+use Lullabot\Mpx\DataService\Media\Media as MpxMedia;
+use Lullabot\Mpx\Service\Player\Url;
+
+/**
+ * Player metadata class.
+ *
+ * Build the metadata keys for schema.org tags.
+ */
+class PlayerMetadata {
+
+  /**
+   * Drupal media entity.
+   *
+   * @var \Drupal\media\Entity\Media
+   */
+  protected $drupalMedia;
+
+  /**
+   * Mpx media data service object.
+   *
+   * @var \Lullabot\Mpx\DataService\Media\Media
+   */
+  protected $mpxMedia;
+
+  /**
+   * Player URL.
+   *
+   * @var \Lullabot\Mpx\Service\Player\Url
+   */
+  protected $playerUrl;
+
+  /**
+   * Constructs a PlayerMetadata object.
+   *
+   * @param \Drupal\media\Entity\Media $drupal_media
+   *   Drupal media entity.
+   * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
+   *   Mpx media data service object.
+   * @param \Lullabot\Mpx\Service\Player\Url $player_url
+   *   Player URL.
+   */
+  public function __construct(DrupalMedia $drupal_media, MpxMedia $mpx_media, Url $player_url) {
+    $this->drupalMedia = $drupal_media;
+    $this->mpxMedia = $mpx_media;
+    $this->playerUrl = $player_url;
+  }
+
+  /**
+   * Convert this object to an array.
+   *
+   * Suitable for use as 'meta' property of the 'media_mpx_iframe_wrapper' theme
+   * hook, which are the keys for scheme.org tags output with an MPX player.
+   *
+   * @return array
+   *   Metadata keys for schema.org tags.
+   */
+  public function toArray() {
+    $source_plugin = $this->drupalMedia->getSource();
+    return [
+      'name' => $this->drupalMedia->label(),
+      'thumbnailUrl' => file_create_url($source_plugin->getMetadata($this->drupalMedia, 'thumbnail_uri')),
+      'description' => $this->mpxMedia->getDescription(),
+      'uploadDate' => $this->mpxMedia->getAvailableDate()->format(DATE_ISO8601),
+      'embedUrl' => (string) $this->playerUrl->withEmbed(TRUE),
+    ];
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
@@ -126,21 +126,23 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
 
     /** @var \Drupal\media\Entity\Media $entity */
     $entity = $items->getEntity();
-    /** @var \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin */
-    $source_plugin = $entity->getSource();
+    if ($entity) {
+      /** @var \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin */
+      $source_plugin = $entity->getSource();
 
-    // @todo Cache this.
-    $factory = $this->dataObjectFactoryCreator->forObjectType($source_plugin->getAccount()->getUserEntity(), 'Player Data Service', 'Player', '1.6');
+      // @todo Cache this.
+      $factory = $this->dataObjectFactoryCreator->forObjectType($source_plugin->getAccount()->getUserEntity(), 'Player Data Service', 'Player', '1.6');
 
-    try {
-      $player = $factory->load(new Uri($this->getSetting('player')))->wait();
+      try {
+        $player = $factory->load(new Uri($this->getSetting('player')))->wait();
+      }
+      catch (TransferException $e) {
+        // If we can't load a player, we can't render any elements.
+        $this->mpxLogger->logException($e);
+        return $element;
+      }
+      $this->renderIframes($items, $player, $element);
     }
-    catch (TransferException $e) {
-      // If we can't load a player, we can't render any elements.
-      $this->mpxLogger->logException($e);
-      return $element;
-    }
-    $this->renderIframes($items, $player, $element);
 
     return $element;
   }
@@ -227,25 +229,28 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
   protected function fetchPlayerOptions(): array {
     $options = [];
     $bundle = $this->fieldDefinition->getTargetBundle();
-    /** @var \Drupal\media\Entity\MediaType $type */
-    $type = $this->entityTypeManager->getStorage('media_type')->load($bundle);
-    /** @var \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin */
-    $source_plugin = $type->getSource();
+    if ($bundle) {
+      /** @var \Drupal\media\Entity\MediaType $type */
+      $type = $this->entityTypeManager->getStorage('media_type')->load($bundle);
+      /** @var \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin */
+      $source_plugin = $type->getSource();
 
-    $factory = $this->dataObjectFactoryCreator->forObjectType($source_plugin->getAccount()->getUserEntity(), 'Player Data Service', 'Player', '1.6', $source_plugin->getAccount());
-    $query = new ObjectListQuery();
-    $sort = new Sort();
-    $sort->addSort('title');
-    $query->setSort($sort);
+      $factory = $this->dataObjectFactoryCreator->forObjectType($source_plugin->getAccount()->getUserEntity(), 'Player Data Service', 'Player', '1.6', $source_plugin->getAccount());
+      $query = new ObjectListQuery();
+      $sort = new Sort();
+      $sort->addSort('title');
+      $query->setSort($sort);
 
-    /** @var \Lullabot\Mpx\DataService\Player\Player[] $results */
-    $results = $factory->select($query);
+      /** @var \Lullabot\Mpx\DataService\Player\Player[] $results */
+      $results = $factory->select($query);
 
-    foreach ($results as $player) {
-      if (!$player->getDisabled()) {
-        $options[(string) $player->getId()] = $player->getTitle();
+      foreach ($results as $player) {
+        if (!$player->getDisabled()) {
+          $options[(string) $player->getId()] = $player->getTitle();
+        }
       }
     }
+
     return $options;
   }
 

--- a/src/Plugin/media/Source/FeedConfig.php
+++ b/src/Plugin/media/Source/FeedConfig.php
@@ -57,29 +57,7 @@ class FeedConfig extends MediaSourceBase implements MediaSourceInterface {
     if (!$media->get($source_field->getName())->isEmpty()) {
       switch ($attribute_name) {
         case 'thumbnail_uri':
-          // Unlike the rest of the mpx API, these IDs are numeric and don't
-          // include the host name.
-          $factory = $this->dataObjectFactoryCreator->forObjectType($this->getAccount()->getUserEntity(), 'Media Data Service', 'Media', '1.10');
-
-          /** @var \Lullabot\Mpx\DataService\Feeds\FeedConfig $feed */
-          $feed = $this->getMpxObject($media);
-          $pinned_ids = $feed->getPinnedIds();
-          foreach ($pinned_ids as $video_id) {
-
-            try {
-              $video = $factory->loadByNumericId($video_id)->wait();
-              return $this->downloadThumbnail($video);
-            }
-            catch (ClientException $e) {
-              // Mpx doesn't removed pinned videos from feeds if the video is
-              // deleted. In that case, we go on to the next video to find a
-              // thumbnail.
-              if ($e->getCode() != 404) {
-                throw $e;
-              }
-            }
-          }
-
+          $this->getThumbnailUri($media);
           break;
 
         case 'thumbnail_alt':
@@ -95,6 +73,57 @@ class FeedConfig extends MediaSourceBase implements MediaSourceInterface {
     };
 
     return parent::getMetadata($media, $attribute_name);
+  }
+
+  /**
+   * Return the thumbnail for a feed.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The feed config media entity.
+   *
+   * @return string|null
+   *   The thumbnail URL, or NULL if one cannot be found.
+   */
+  private function getThumbnailUri(MediaInterface $media): ?string {
+    /** @var \Lullabot\Mpx\DataService\Feeds\FeedConfig $feed */
+    $feed = $this->getMpxObject($media);
+    $pinned_ids = $feed->getPinnedIds();
+    // Unlike the rest of the mpx API, these IDs are numeric and don't
+    // include the host name.
+    foreach ($pinned_ids as $video_id) {
+      if ($thumbnail = $this->fetchFromPinnedId($video_id)) {
+        return $thumbnail;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Fetch a thumbnail for a pinned video.
+   *
+   * @param int $video_id
+   *   The video ID to load.
+   *
+   * @return string|null
+   *   The thumbnail URL, or NULL if one cannot be found.
+   */
+  private function fetchFromPinnedId(int $video_id) {
+    $factory = $this->dataObjectFactoryCreator->forObjectType($this->getAccount()->getUserEntity(), 'Media Data Service', 'Media', '1.10');
+    try {
+      $video = $factory->loadByNumericId($video_id)->wait();
+      return $this->downloadThumbnail($video);
+    }
+    catch (ClientException $e) {
+      // Mpx doesn't removed pinned videos from feeds if the video is
+      // deleted. In that case, we go on to the next video to find a
+      // thumbnail.
+      if ($e->getCode() != 404) {
+        throw $e;
+      }
+    }
+
+    return NULL;
   }
 
 }

--- a/src/Plugin/migrate/source/MediaMpxType.php
+++ b/src/Plugin/migrate/source/MediaMpxType.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\media_mpx\Plugin\migrate\source;
 
-use Drupal\paragraphs\Plugin\migrate\source\DrupalSqlBase;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
 
 /**
  * Mpx Type source plugin.


### PR DESCRIPTION
Original issue: https://github.com/nbc-bravo/drupal-media_mpx/issues/20

I installed https://www.drupal.org/project/readonly_field_widget
and configured to `mpx_video_17` form display (I changed all fields to READ ONLY and getting below error:
![image](https://user-images.githubusercontent.com/1582129/57534187-1a9c6a80-7305-11e9-9782-c4d79ccafc3b.png)

I don't think the issue may come directly to readonly_field_widget.
My proposal fix is to add defensive programming(make sure the entity object exists!)
