### PR TITLE
LogicException: The database connection is not serializable error on mpx media forms with AJAX operations

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -3,5 +3,6 @@ Fix not being able to import "0" strings and integers #110
 Fix error on connection timeout during notification listen
 * https://github.com/Lullabot/media_mpx/pull/116.diff
 Import single messaging for filtered videos
-* https://github.com/Lullabot/media_mpx/pull/143
-
+* https://github.com/Lullabot/media_mpx/pull/143.diff
+LogicException: The database connection is not serializable error on mpx media forms with AJAX operations
+* https://github.com/Lullabot/media_mpx/pull/145.diff

--- a/src/Service/UpdateVideoItem/UpdateVideoItem.php
+++ b/src/Service/UpdateVideoItem/UpdateVideoItem.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\media_mpx\Service\UpdateVideoItem;
 
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\media_mpx\DataObjectFactoryCreator;
 use Drupal\media_mpx\DataObjectImporter;
 use Drupal\media_mpx\Repository\MpxMediaType;
@@ -14,6 +15,7 @@ use Drupal\media_mpx\Repository\MpxMediaType;
  * @package Drupal\media_mpx\Service\ImportVideoItem
  */
 class UpdateVideoItem {
+  use DependencySerializationTrait;
 
   /**
    * The Data Object Importer.


### PR DESCRIPTION
Patch to include upstream https://github.com/Lullabot/media_mpx/pull/145